### PR TITLE
new link for income data

### DIFF
--- a/notebooks/analyze-customer-data.ipynb
+++ b/notebooks/analyze-customer-data.ipynb
@@ -595,7 +595,7 @@
    "outputs": [],
    "source": [
     "# Load median income information for all US ZIP codes from a public source\n",
-    "income_df = pixiedust.sampleData('https://apsportal.ibm.com/exchange-api/v1/entries/beb8c30a3f559e58716d983671b70337/data?accessKey=1c0b5b6d465fefec1ab529fde04997af')"
+    "income_df = pixiedust.sampleData('https://raw.githubusercontent.com/IBM/analyze-customer-data-spark-pixiedust/master/data/x19_income_select.csv')"
    ]
   },
   {


### PR DESCRIPTION
The old link goes to an out of date watson studio asset, I could still download it, so I saved it in commit https://github.com/IBM/analyze-customer-data-spark-pixiedust/commit/54e06e72f5402f5e39b8e8f76e0efe44bee4bc9c and point to the new path https://github.com/IBM/analyze-customer-data-spark-pixiedust/blob/master/data/x19_income_select.csv in this patch.

Closes: #5 